### PR TITLE
Part2

### DIFF
--- a/polls/admin.py
+++ b/polls/admin.py
@@ -1,3 +1,5 @@
 from django.contrib import admin
 
-# Register your models here.
+from .models import Question
+
+admin.site.register(Question)

--- a/polls/admin.py
+++ b/polls/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from .models import Question
+from .models import Choice, Question
 
 # カスタマイズ無し
 # admin.site.register(Question)
@@ -24,4 +24,29 @@ class QuestionAdmin3(admin.ModelAdmin):
         (None, {'fields': ['question_text']}),
         ('Date information', {'fields': ['pub_date'], 'classes': ['collapse']}),
     ]
-admin.site.register(Question, QuestionAdmin3)
+# admin.site.register(Question, QuestionAdmin3)
+
+
+# Choice model の画面への追加
+# admin.site.register(Choice)
+
+# QuestionとChoiceの登録を一括で行う
+class ChoiceInline(admin.StackedInline):
+    model = Choice
+    extra = 3
+
+# table-baseなフォーマットの場合
+class ChoiceInline2(admin.TabularInline):
+    model = Choice
+    extra = 3
+
+class QuestionAdmin4(admin.ModelAdmin):
+    fieldsets = [
+        (None, {'fields': ['question_text']}),
+        ('Date information', {'fields': ['pub_date'], 'classes': ['collapse']}),
+    ]
+    # inlines = [ChoiceInline] #標準的な一括登録
+    inlines = [ChoiceInline2]   # テーブル的な表現のコンパクトな一括登録
+
+
+admin.site.register(Question, QuestionAdmin4)

--- a/polls/admin.py
+++ b/polls/admin.py
@@ -2,4 +2,26 @@ from django.contrib import admin
 
 from .models import Question
 
-admin.site.register(Question)
+# カスタマイズ無し
+# admin.site.register(Question)
+
+# 列の並び順をカスタマイズ
+class QuestionAdmin(admin.ModelAdmin):
+    fields = ['pub_date', 'question_text']
+# admin.site.register(Question, QuestionAdmin)
+
+# 列の区切りをカスタマイズ
+class QuestionAdmin2(admin.ModelAdmin):
+    fieldsets = [
+        (None, {'fields': ['question_text']}),
+        ('Date information', {'fields': ['pub_date'] }),
+    ]
+# admin.site.register(Question, QuestionAdmin2)
+
+# 列の表示を隠す
+class QuestionAdmin3(admin.ModelAdmin):
+    fieldsets = [
+        (None, {'fields': ['question_text']}),
+        ('Date information', {'fields': ['pub_date'], 'classes': ['collapse']}),
+    ]
+admin.site.register(Question, QuestionAdmin3)

--- a/polls/admin.py
+++ b/polls/admin.py
@@ -48,5 +48,14 @@ class QuestionAdmin4(admin.ModelAdmin):
     # inlines = [ChoiceInline] #標準的な一括登録
     inlines = [ChoiceInline2]   # テーブル的な表現のコンパクトな一括登録
 
+    # 一覧画面で表示する項目
+    # modelの関数も表示できる
+    list_display = ('question_text', 'pub_date', 'was_published_recently')
+
+    # 一覧画面でフィルターできる項目、右側にフィルタ情報が出てくる
+    list_filter = ['pub_date']
+
+    # 一覧画面で検索できる項目、ヘッダの上に検索項目が出てくる
+    search_fields = ['question_text']
 
 admin.site.register(Question, QuestionAdmin4)

--- a/polls/models.py
+++ b/polls/models.py
@@ -13,6 +13,10 @@ class Question(models.Model):
     def was_published_recently(self):
         return self.pub_date >= timezone.now() - datetime.timedelta(days=1)
 
+    # `was_published_recently`に対する、admin画面での表示設定
+    was_published_recently.admin_order_field = 'pub_date'
+    was_published_recently.boolean = True
+    was_published_recently.short_description = 'Published recently?'
 
 class Choice(models.Model):
     question = models.ForeignKey(Question)

--- a/templates/admin/base_site.html
+++ b/templates/admin/base_site.html
@@ -1,0 +1,10 @@
+{% extends "admin/base.html" %}
+
+{% block title %}{{ title }} | {{ site_title|default:_('Django site admin') }}{% endblock %}
+
+{% block branding %}
+<h1 id="site-name"><a href="{% url 'admin:index' %}">Polls Administration</a></h1>
+{#    <h1 id="site-name"><a href="{% url 'admin:index' %}">{{ site_header|default:_('Site administration') }}</a></h1>#}
+{% endblock %}
+
+{% block nav-global %}{% endblock %}


### PR DESCRIPTION
## メモ
- `admin.py`に`admin.site.register(Question)`とすることで、管理者画面にModelを追加
- fieldの列順指定
  - ModelAdminを継承して、fieldに該当列を指定
  - registerには、第二引数に`QuestionAdmin`を指定

``` python
class QuestionAdmin(admin.ModelAdmin):
    fields = ['pub_date', 'question_text']

admin.site.register(Question, QuestionAdmin)
```
- fieldの装飾
  - fieldsetsの一番最初の引数に、タイトルを入れることで、項目の上にタイトルが表示される

``` python
class QuestionAdmin2(admin.ModelAdmin):
    fieldsets = [
        (None, {'fields': ['question_text']}),
        ('Date Information', {'fields': ['pub_date']}),
    ]
```
- classesでcollapseを渡すと、項目を隠すことができる

``` python
('Date Information', {'fields': ['pub_date'], 'classes': ['collapse']}),
```
- 親子関係のあるmodelを一括で登録

``` python
class ChoiceInline(admin.StackedInline):
    model = Choice
    extra = 3

class QuestionAdmin4(admin.ModelAdmin):
    fieldsets = [
        (None, {'fields': ['question_text']}),
        ('Date information', {'fields': ['pub_date'], 'classes': ['collapse']}),
    ]
    # inlinesで、一括登録したいmodelを指定
    inlines = [ChoiceInline]
```
- `StackedInline`の代わりに、`TabularInline`を使うと、テーブルをベースとしたコンパクトなものができる
## 調べる
- `.models`という書き方はどういう意味か
