### PR TITLE
Part3

### DIFF
--- a/Django_official_tutorial/urls.py
+++ b/Django_official_tutorial/urls.py
@@ -17,6 +17,6 @@ from django.conf.urls import include, url
 from django.contrib import admin
 
 urlpatterns = [
-    url(r'^polls/' , include('polls.urls')),
+    url(r'^polls/' , include('polls.urls', namespace='polls')),
     url(r'^admin/', include(admin.site.urls)),
 ]

--- a/Django_official_tutorial/urls.py
+++ b/Django_official_tutorial/urls.py
@@ -17,5 +17,6 @@ from django.conf.urls import include, url
 from django.contrib import admin
 
 urlpatterns = [
+    url(r'^polls/' , include('polls.urls')),
     url(r'^admin/', include(admin.site.urls)),
 ]

--- a/polls/templates/polls/detail.html
+++ b/polls/templates/polls/detail.html
@@ -1,0 +1,1 @@
+{{ question }}

--- a/polls/templates/polls/detail.html
+++ b/polls/templates/polls/detail.html
@@ -1,1 +1,6 @@
-{{ question }}
+<h1>{{ question.question_text }}</h1>
+<ul>
+    {% for choice in question.choice_set.all %}
+        <li>{{ choice.choice_text }}</li>
+    {% endfor %}
+</ul>

--- a/polls/templates/polls/index.html
+++ b/polls/templates/polls/index.html
@@ -1,0 +1,9 @@
+{% if latest_question_list %}
+    <ul>
+        {% for question in latest_question_list %}
+            <li><a href="/polls/{{ question.id }}/">{{ question.question_text }}</a></li>
+        {% endfor %}
+    </ul>
+{% else %}
+    <p>No polls are available.</p>
+{% endif %}

--- a/polls/templates/polls/index.html
+++ b/polls/templates/polls/index.html
@@ -1,7 +1,11 @@
 {% if latest_question_list %}
     <ul>
         {% for question in latest_question_list %}
-            <li><a href="/polls/{{ question.id }}/">{{ question.question_text }}</a></li>
+{#          -  hardcode ver#}
+{#          <li><a href="/polls/{{ question.id }}/">{{ question.question_text }}</a></li>#}
+{#          -  url template tag #}
+            <li><a href="{% url 'detail' question.id %}">{{ question.question_text }}</a></li>
+
         {% endfor %}
     </ul>
 {% else %}

--- a/polls/templates/polls/index.html
+++ b/polls/templates/polls/index.html
@@ -4,7 +4,7 @@
 {#          -  hardcode ver#}
 {#          <li><a href="/polls/{{ question.id }}/">{{ question.question_text }}</a></li>#}
 {#          -  url template tag #}
-            <li><a href="{% url 'detail' question.id %}">{{ question.question_text }}</a></li>
+            <li><a href="{% url 'polls:detail' question.id %}">{{ question.question_text }}</a></li>
 
         {% endfor %}
     </ul>

--- a/polls/urls.py
+++ b/polls/urls.py
@@ -1,0 +1,7 @@
+from django.conf.urls import url
+
+from . import views
+
+urlpatterns = [
+    url(r'^$', views.index, name='index'),
+]

--- a/polls/urls.py
+++ b/polls/urls.py
@@ -3,5 +3,12 @@ from django.conf.urls import url
 from . import views
 
 urlpatterns = [
+    # /polls/
     url(r'^$', views.index, name='index'),
+    # /polls/5/
+    url(r'^(?P<question_id>[0-9]+)/$', views.detail, name='detail'),
+    # /polls/5/results/
+    url(r'^(?P<question_id>[0-9]+)/results/$', views.results, name='results'),
+    # /polls/5/vote/
+    url(r'^(?P<question_id>[0-9]+)/vote/$', views.vote, name='vote'),
 ]

--- a/polls/urls.py
+++ b/polls/urls.py
@@ -6,6 +6,7 @@ urlpatterns = [
     # /polls/
     url(r'^$', views.index, name='index'),
     # /polls/5/
+    # nameの値は、{% url %} テンプレートタグで呼び出される
     url(r'^(?P<question_id>[0-9]+)/$', views.detail, name='detail'),
     # /polls/5/results/
     url(r'^(?P<question_id>[0-9]+)/results/$', views.results, name='results'),

--- a/polls/views.py
+++ b/polls/views.py
@@ -1,3 +1,4 @@
-from django.shortcuts import render
+from django.shortcuts import HttpResponse
 
-# Create your views here.
+def index(request):
+    return HttpResponse("Hello, world. You're at the polls index.")

--- a/polls/views.py
+++ b/polls/views.py
@@ -2,3 +2,13 @@ from django.shortcuts import HttpResponse
 
 def index(request):
     return HttpResponse("Hello, world. You're at the polls index.")
+
+def detail(request, question_id):
+    return HttpResponse("You're looking at question %s." % question_id)
+
+def results(request, question_id):
+    response = HttpResponse("You're looking at the results of question %s.")
+    return HttpResponse(response % question_id)
+
+def vote(request, question_id):
+    return HttpResponse("You're voting on question %s." % question_id)

--- a/polls/views.py
+++ b/polls/views.py
@@ -1,6 +1,7 @@
 from django.shortcuts import HttpResponse
 from django.template import RequestContext, loader
-from django.shortcuts import render
+from django.http import Http404
+from django.shortcuts import render, get_object_or_404
 
 from .models import Question
 
@@ -19,7 +20,20 @@ def index(request):
     # return HttpResponse("Hello, world. You're at the polls index.")
 
 def detail(request, question_id):
-    return HttpResponse("You're looking at question %s." % question_id)
+
+    # Response:
+    # - full
+    # try:
+    #     question = Question.objects.get(pk=question_id)
+    # except Question.DoesNotExist:
+    #     raise Http404("Question does not exist")
+    # return render(request, 'polls/detail.html', {'question': question})
+    #
+    # - shortcut
+    question = get_object_or_404(Question, pk=question_id)
+    return render(request, 'polls/detail.html', {'question': question})
+
+    # return HttpResponse("You're looking at question %s." % question_id)
 
 def results(request, question_id):
     response = HttpResponse("You're looking at the results of question %s.")

--- a/polls/views.py
+++ b/polls/views.py
@@ -1,7 +1,22 @@
 from django.shortcuts import HttpResponse
+from django.template import RequestContext, loader
+from django.shortcuts import render
+
+from .models import Question
 
 def index(request):
-    return HttpResponse("Hello, world. You're at the polls index.")
+    latest_question_list = Question.objects.order_by('-pub_date')[:5]
+    template = loader.get_template('polls/index.html')
+    context = RequestContext(request, {
+        'latest_question_list': latest_question_list,
+    })
+    # Response:
+    # - full
+    # return HttpResponse(template.render(context))
+    # - shortcut
+    return render(request, 'polls/index.html', context)
+
+    # return HttpResponse("Hello, world. You're at the polls index.")
 
 def detail(request, question_id):
     return HttpResponse("You're looking at question %s." % question_id)


### PR DESCRIPTION
## メモ
- 公式でもurlsの作り方は、
  - アプリに urls.pyを作る
  - プロジェクトでinclude
- %は変数に入れた後でも編集可能 (Pythonの話)

``` python
response = "You're looking at the results of question %s."
return HttpResponse(response % question_id)
```
- nameの値は、{% url %} テンプレートタグで呼び出される

``` python
url(r'^(?P<question_id>[0-9]+)/$', views.detail, name='detail'),
```
- プロジェクトのurls.pyで指定する`namespace`の値

```
urlpatterns = [
    url(r'^polls/' , include('polls.urls', namespace='polls')),
    url(r'^admin/', include(admin.site.urls)),
]
```

は、templateで指定して使う (アプリ数が多くなった時に区別するため)

```
# 下記で `polls:detail` として名前空間`polls`を指定している
<li><a href="{% url 'polls:detail' question.id %}">{{ question.question_text }}</a></li>
```
## 調べる
- adminの前に、各アプリのurlsを指定するのはなぜか？
  - admin.autodiscover() の影響？
- 以下の意味を調べる
  - nameとは
  - `<question_id>`とは

``` python
# /polls/5/
url(r'^(?P<question_id>[0-9]+)/$', views.detail, name='detail'),
```
